### PR TITLE
Optimise posteiror marginals and Zygote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk>"]
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/util/gaussian.jl
+++ b/src/util/gaussian.jl
@@ -24,6 +24,10 @@ AbstractGPs.mean(x::Gaussian) = Zygote.literal_getfield(x, Val(:m))
 
 AbstractGPs.cov(x::Gaussian) = Zygote.literal_getfield(x, Val(:P))
 
+AbstractGPs.var(x::Gaussian{<:AbstractVector}) = diag(cov(x))
+
+AbstractGPs.var(x::Gaussian{<:Real}) = cov(x)
+
 get_fields(x::Gaussian) = mean(x), cov(x)
 
 Random.rand(rng::AbstractRNG, x::Gaussian) = vec(rand(rng, x, 1))
@@ -54,7 +58,7 @@ function Base.isapprox(x::Gaussian, y::Gaussian; kwargs...)
     return isapprox(mean(x), mean(y); kwargs...) && isapprox(cov(x), cov(y); kwargs...)
 end
 
-AbstractGPs.marginals(x::Gaussian{<:Real, <:Real}) = Normal(mean(x), sqrt(cov(x)))
+AbstractGPs.marginals(x::Gaussian{T, T}) where {T<:Real} = Normal{T}(mean(x), sqrt(cov(x)))
 
 function AbstractGPs.marginals(x::Gaussian{<:AbstractVector, <:AbstractMatrix})
     return Normal.(mean(x), sqrt.(diag(cov(x))))


### PR DESCRIPTION
A variety of optimisations.

If the posterior is queried at precisely the same locations as those at which it was constructed, then a large amount of book-keeping can be skipped.

There are various Zygote optimisations added to work around [this PR](https://github.com/FluxML/Zygote.jl/pull/909) not being in yet.