### PR TITLE
Update compat entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,9 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-AbstractGPs = "0.2, 0.3"
+AbstractGPs = "0.2, 0.3, 0.4, 0.5"
 BlockDiagonals = "0.1.7"
-ChainRulesCore = "0.9, 0.10"
+ChainRulesCore = "0.9, 0.10, 1"
 FillArrays = "0.10, 0.11, 0.12"
 KernelFunctions = "0.9, 0.10.1"
 StaticArrays = "1"


### PR DESCRIPTION
This unblocks the ChainRulesCore dependency constraint and allows TemporalGPs to be loaded alongside GPLikelihoods and the current version of AbstractGPs. 