### PR TITLE
Refactor treatment of `KernelSum`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk> and contributors"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/gp/lti_sde.jl
+++ b/src/gp/lti_sde.jl
@@ -293,13 +293,13 @@ function lgssm_components(k::KernelSum, ts::AbstractVector, storage_type::Storag
     As = _map(block_diagonal, As_kernels...)
     as = _map(vcat, as_kernels...)
     Qs = _map(block_diagonal, Qs_kernels...)
-    emission_projections = _sum_emission_projections(emission_proj_kernels)
-    x0 = Gaussian(mapreduce(x -> getproperty(x, :m), x0_kernels), block_diagonal(getproperty.(x0_kernels, :P)...))
+    emission_projections = _sum_emission_projections(emission_proj_kernels...)
+    x0 = Gaussian(mapreduce(x -> getproperty(x, :m), vcat, x0_kernels), block_diagonal(getproperty.(x0_kernels, :P)...))
     return As, as, Qs, emission_projections, x0
 end
 
 function _sum_emission_projections(Hs_hs::Tuple{AbstractVector, AbstractVector}...)
-    return map(vcat, first.(Hs_hs)), sum(last.(hs))
+    return map(vcat, first.(Hs_hs)...), sum(last.(Hs_hs))
 end
 
 function _sum_emission_projections(

--- a/src/space_time/pseudo_point.jl
+++ b/src/space_time/pseudo_point.jl
@@ -383,11 +383,12 @@ function dtc_post_emissions(k::ScaledKernel, x_new::AbstractVector, storage::Sto
 end
 
 function dtc_post_emissions(k::KernelSum, x_new::AbstractVector, storage::StorageType)
-    (Cs_l, cs_l, Hs_l, hs_l), Σs_l = dtc_post_emissions(k.kernels[1], x_new, storage)
-    (Cs_r, cs_r, Hs_r, hs_r), Σs_r = dtc_post_emissions(k.kernels[2], x_new, storage)
-    Cs = _map(vcat, Cs_l, Cs_r)
-    cs = cs_l + cs_r
-    Hs = _map(block_diagonal, Hs_l, Hs_r)
-    hs = _map(vcat, hs_l, hs_r)
-    return (Cs, cs, Hs, hs), _map(+, Σs_l, Σs_r)
+    post_emissions = dtc_post_emissions.(k.kernels, Ref(x_new), Ref(storage))
+    Cs_cs_Hs_hs = getindex.(post_emissions, 1)
+    Σs = getindex.(post_emissions, 2)
+    Cs = _map(vcat, getindex.(Cs_cs_Hs_hs, 1)...)
+    cs = sum(getindex.(Cs_cs_Hs_hs, 2))
+    Hs = _map(block_diagonal, getindex.(Cs_cs_Hs_hs, 3)...)
+    hs = _map(vcat, getindex.(Cs_cs_Hs_hs, 4)...)
+    return (Cs, cs, Hs, hs), sum(Σs)
 end

--- a/src/space_time/pseudo_point.jl
+++ b/src/space_time/pseudo_point.jl
@@ -387,7 +387,7 @@ function dtc_post_emissions(k::KernelSum, x_new::AbstractVector, storage::Storag
     (Cs_r, cs_r, Hs_r, hs_r), Σs_r = dtc_post_emissions(k.kernels[2], x_new, storage)
     Cs = _map(vcat, Cs_l, Cs_r)
     cs = cs_l + cs_r
-    Hs = _map(blk_diag, Hs_l, Hs_r)
+    Hs = _map(block_diagonal, Hs_l, Hs_r)
     hs = _map(vcat, hs_l, hs_r)
     return (Cs, cs, Hs, hs), _map(+, Σs_l, Σs_r)
 end

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -72,12 +72,19 @@ println("lti_sde:")
                 (name="stretched-λ=$λ", val=Matern32Kernel() ∘ ScaleTransform(λ))
             end,
 
+            # TEST_TOFIX
             # Summed kernels.
             # (
-                # name="sum-Matern12Kernel-Matern32Kernel",
-                # val=1.5 * Matern12Kernel() ∘ ScaleTransform(0.1) +
-                    # 0.3 * Matern32Kernel() ∘ ScaleTransform(1.1),
-            # ), # TEST_TOFIX
+            #     name="sum-Matern12Kernel-Matern32Kernel",
+            #     val=1.5 * Matern12Kernel() ∘ ScaleTransform(0.1) +
+            #         0.3 * Matern32Kernel() ∘ ScaleTransform(1.1),
+            # ), 
+            # (
+            #     name="sum-Matern32Kernel-Matern52Kernel-ConstantKernel",
+            #     val = 2.0 * Matern32Kernel() +
+            #         0.5 * Matern52Kernel() +
+            #         1.0 * ConstantKernel(),
+            # ),
         )
 
         # Construct a Gauss-Markov model with either dense storage or static storage.

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -15,11 +15,12 @@ end
 println("lti_sde:")
 @testset "lti_sde" begin
 
-    @testset "blk_diag" begin
+    @testset "block_diagonal" begin
         A = randn(2, 2)
         B = randn(3, 3)
-        test_rrule(TemporalGPs.blk_diag, A, B; check_inferred=false)
-        test_rrule(TemporalGPs.blk_diag, SMatrix{2, 2}(A), SMatrix{3, 3}(B))
+        C = randn(5, 5)
+        test_rrule(TemporalGPs.block_diagonal, A, B, C; check_inferred=false)
+        test_rrule(TemporalGPs.block_diagonal, SMatrix{2, 2}(A), SMatrix{3, 3}(B), SMatrix{5, 5}(C); check_inferred=false)
     end
 
     @testset "SimpleKernel parameter types" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ ENV["TESTING"] = "TRUE"
 # ["test util", "test models" "test models-lgssm" "test gp" "test space_time"]
 # Select any of this to test a particular aspect.
 # To test everything, simply set GROUP to "all"
-# ENV["GROUP"] = "test space_time"
+ENV["GROUP"] = "test gp"
 const GROUP = get(ENV, "GROUP", "test")
 OUTER_GROUP = first(split(GROUP, ' '))
 

--- a/test/util/mul.jl
+++ b/test/util/mul.jl
@@ -11,8 +11,8 @@ using LinearAlgebra: mul!
     A_Matrix = randn(rng, P, Q)
     At_Matrix = collect(A_Matrix')
 
-    A_blk_diag = BlockDiagonal([randn(rng, P, P), randn(rng, P + 1, P + 1)])
-    At_blk_diag = BlockDiagonal(map(collect ∘ transpose, blocks(A_blk_diag)))
+    A_block_diag = BlockDiagonal([randn(rng, P, P), randn(rng, P + 1, P + 1)])
+    At_block_diag = BlockDiagonal(map(collect ∘ transpose, blocks(A_block_diag)))
 
     settings = [
         (
@@ -24,17 +24,17 @@ using LinearAlgebra: mul!
         ),
         (
             name="BlockDiagonal{Float64, Matrix{Float64}}",
-            A=A_blk_diag,
-            At=At_blk_diag,
-            B=randn(rng, size(A_blk_diag, 2), Q),
-            C=randn(rng, size(A_blk_diag, 1), Q),
+            A=A_block_diag,
+            At=At_block_diag,
+            B=randn(rng, size(A_block_diag, 2), Q),
+            C=randn(rng, size(A_block_diag, 1), Q),
         ),
         (
             name="BlockDiagonal{Float64, BlockDiagonal{Float64, Matrix{Float64}}}",
-            A=BlockDiagonal([A_blk_diag, A_blk_diag]),
-            At=BlockDiagonal([At_blk_diag, At_blk_diag]),
-            B=randn(rng, 2 * size(A_blk_diag, 2), Q),
-            C=randn(rng, 2 * size(A_blk_diag, 1), Q),
+            A=BlockDiagonal([A_block_diag, A_block_diag]),
+            At=BlockDiagonal([At_block_diag, At_block_diag]),
+            B=randn(rng, 2 * size(A_block_diag, 2), Q),
+            C=randn(rng, 2 * size(A_block_diag, 1), Q),
         ),
     ]
 


### PR DESCRIPTION
Addresses #64 by allowing an arbitrary number of kernels in a `KernelSum` (and not only 2).
This also includes a revamp of the `blk_diag` -> `block_diagonal` to accept an arbitrary number of elements.
One potential alternative to make this simpler would be to use `BlockArrays` but I am not sure it would be that much efficient and it would highly restrict the type of the inferred matrices.