### PR TITLE
Dispatch on `to_sde` rather than `lgssm_components`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk> and contributors"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -71,19 +71,39 @@ println("lti_sde:")
                 (; name="stretched-λ=$λ", val=Matern32Kernel() ∘ ScaleTransform(λ))
             end,
 
-            # TEST_TOFIX
+            # Gradients should be fixed on those composites.
+            # Error is mostly due do an incompatibility of Tangents
+            # between Zygote and FiniteDifferences.
+
+            # Product kernels
+            (
+                name="prod-Matern12Kernel-Matern32Kernel",
+                val=1.5 * Matern12Kernel() ∘ ScaleTransform(0.1) *
+                    Matern32Kernel() ∘ ScaleTransform(1.1),
+                skip_grad=true,
+                ), 
+                (
+                name="prod-Matern32Kernel-Matern52Kernel-ConstantKernel",
+                val = 3.0 * Matern32Kernel() *
+                    Matern52Kernel() *
+                    ConstantKernel(),
+                skip_grad=true,
+            ),
+
             # Summed kernels.
-            # (
-            #     name="sum-Matern12Kernel-Matern32Kernel",
-            #     val=1.5 * Matern12Kernel() ∘ ScaleTransform(0.1) +
-            #         0.3 * Matern32Kernel() ∘ ScaleTransform(1.1),
-            # ), 
-            # (
-            #     name="sum-Matern32Kernel-Matern52Kernel-ConstantKernel",
-            #     val = 2.0 * Matern32Kernel() +
-            #         0.5 * Matern52Kernel() +
-            #         1.0 * ConstantKernel(),
-            # ),
+            (
+                name="sum-Matern12Kernel-Matern32Kernel",
+                val=1.5 * Matern12Kernel() ∘ ScaleTransform(0.1) +
+                    0.3 * Matern32Kernel() ∘ ScaleTransform(1.1),
+                skip_grad=true,
+            ), 
+            (
+                name="sum-Matern32Kernel-Matern52Kernel-ConstantKernel",
+                val = 2.0 * Matern32Kernel() +
+                    0.5 * Matern52Kernel() +
+                    1.0 * ConstantKernel(),
+                skip_grad=true,
+            ),
         )
 
         # Construct a Gauss-Markov model with either dense storage or static storage.
@@ -154,16 +174,18 @@ println("lti_sde:")
             end
 
             # Just need to ensure we can differentiate through construction properly.
-            test_zygote_grad(
-                _construction_tester,
-                f_naive,
-                storage.val,
-                σ².val,
-                t.val;
-                check_inferred=false,
-                rtol=1e-6,
-                atol=1e-6,
-            )
+            if !(hasfield(typeof(kernel), :skip_grad) && kernel.skip_grad)
+                test_zygote_grad(
+                    _construction_tester,
+                    f_naive,
+                    storage.val,
+                    σ².val,
+                    t.val;
+                    check_inferred=false,
+                    rtol=1e-6,
+                    atol=1e-6,
+                )
+            end
         end
     end
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -169,6 +169,14 @@ function to_vec(f::GP)
     return gp_vec, GP_from_vec
 end
 
+function to_vec(k::ConstantKernel)
+    c, c_to_vec = to_vec(k.c)
+    function ConstantKernel_from_vec(c)
+        return ConstantKernel(c=first(c_to_vec(c)))
+    end
+    c, ConstantKernel_from_vec
+end
+
 Base.zero(x::AbstractGPs.ZeroMean) = x
 Base.zero(x::Kernel) = x
 Base.zero(x::TemporalGPs.LTISDE) = x


### PR DESCRIPTION
As mentioned in #105, the representation in `to_sde` feels a bit more natural for time invariant kernels but maybe I am missing something.

Here is a small refactor that does exactly this. It branches out from #105, so #105 should be memrged first.