### PR TITLE
Fix `rrule` for more than 2 Fill

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk> and contributors"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/test/util/chainrules.jl
+++ b/test/util/chainrules.jl
@@ -80,12 +80,16 @@ include("../test_util.jl")
         test_rrule(_map, x -> 2.0 * x, x; check_inferred=false)
         test_rrule(ZygoteRuleConfig(), (x,a)-> _map(x -> x * a, x), x, 2.0; check_inferred=false, rrule_f=rrule_via_ad)
     end
-    @testset "_map(f, x1::Fill, x2::Fill)" begin
+    @testset "_map(f, x::Fill....)" begin
         x1 = Fill(randn(3, 4), 3)
         x2 = Fill(randn(3, 4), 3)
+        x3 = Fill(randn(3, 4), 3)
 
         @test _map(+, x1, x2) == _map(+, collect(x1), collect(x2))
         test_rrule(_map, +, x1, x2; check_inferred=true)
+
+        @test _map(+, x1, x2, x3) == _map(+, collect(x1), collect(x2), collect(x3))
+        test_rrule(_map, +, x1, x2, x3; check_inferred=true)
 
         fsin(x, y) = sin.(x .* y)
         test_rrule(_map, fsin, x1, x2; check_inferred=false)


### PR DESCRIPTION
Should fix #107 

There is a weird indirection that if you use `_map(f, x...)` it does not forward to the `rrule` with vararg arguments.