### PR TITLE
Hacky fix for approx periodic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TemporalGPs"
 uuid = "e155a3c4-0841-43e1-8b83-a0e4f03cc18f"
 authors = ["willtebbutt <wt0881@my.bristol.ac.uk> and contributors"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/gp/lti_sde.jl
+++ b/src/gp/lti_sde.jl
@@ -285,7 +285,7 @@ _ap_error() = throw(error("Unable to construct an ApproxPeriodicKernel for SArra
 to_sde(::ApproxPeriodicKernel, ::SArrayStorage) = _ap_error()
 stationary_distribution(::ApproxPeriodicKernel, ::SArrayStorage) = _ap_error()
 
-function to_sde(::ApproxPeriodicKernel{N}, storage::ArrayStorage{T}) where {T, N}
+function to_sde(::ApproxPeriodicKernel{N}, storage::ArrayStorage{T}) where {T<:Real, N}
 
     # Compute F and H for component processes.
     F, _, H = to_sde(CosineKernel(), storage)
@@ -300,7 +300,7 @@ function to_sde(::ApproxPeriodicKernel{N}, storage::ArrayStorage{T}) where {T, N
     return F, q, H
 end
 
-function stationary_distribution(kernel::ApproxPeriodicKernel{N}, storage::ArrayStorage) where {N}
+function stationary_distribution(kernel::ApproxPeriodicKernel{N}, storage::ArrayStorage{<:Real}) where {N}
     x0 = stationary_distribution(CosineKernel(), storage)
     m = collect(repeat(x0.m, N))
     r = kernel.kernel.r

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -29,7 +29,7 @@ end
     @testset "$(typeof(t)), $storage, $N" for t in (
             sort(rand(Nt)), RegularSpacing(0.0, 0.1, Nt)
         ),
-        storage in (SArrayStorage{Float64}(), ArrayStorage{Float64}()),
+        storage in (ArrayStorage{Float64}(), ),
         N in (5, 8)
 
         k = ApproxPeriodicKernel{N}()

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -131,6 +131,11 @@ println("lti_sde:")
                 val=3.0 * Matern32Kernel() * Matern52Kernel() * ConstantKernel(),
                 to_vec_grad=nothing,
             ),
+            (
+                name="prod-(Matern32Kernel + ConstantKernel) * Matern52Kernel",
+                val=(Matern32Kernel() + ConstantKernel()) * Matern52Kernel(),
+                to_vec_grad=nothing,
+            ),
 
             # Summed kernels.
             (
@@ -149,18 +154,21 @@ println("lti_sde:")
         )
 
         # Construct a Gauss-Markov model with either dense storage or static storage.
-        storages = ((name="dense storage Float64", val=ArrayStorage(Float64)),
-        # (name="static storage Float64", val=SArrayStorage(Float64)),
-)
+        storages = (
+            (name="dense storage Float64", val=ArrayStorage(Float64)),
+            # (name="static storage Float64", val=SArrayStorage(Float64)),
+        )
 
         # Either regular spacing or irregular spacing in time.
-        ts = ((name="irregular spacing", val=collect(RegularSpacing(0.0, 0.3, N))),
-        # (name="regular spacing", val=RegularSpacing(0.0, 0.3, N)),
-)
+        ts = (
+            (name="irregular spacing", val=collect(RegularSpacing(0.0, 0.3, N))),
+            # (name="regular spacing", val=RegularSpacing(0.0, 0.3, N)),
+        )
 
-        σ²s = ((name="homoscedastic noise", val=(0.1,)),
-        # (name="heteroscedastic noise", val=(rand(rng, N) .+ 1e-1, )),
-)
+        σ²s = (
+            (name="homoscedastic noise", val=(0.1,)),
+            # (name="heteroscedastic noise", val=(rand(rng, N) .+ 1e-1, )),
+        )
 
         means = (
             (name="Zero Mean", val=ZeroMean()),

--- a/test/gp/lti_sde.jl
+++ b/test/gp/lti_sde.jl
@@ -131,11 +131,12 @@ println("lti_sde:")
                 val=3.0 * Matern32Kernel() * Matern52Kernel() * ConstantKernel(),
                 to_vec_grad=nothing,
             ),
-            (
-                name="prod-(Matern32Kernel + ConstantKernel) * Matern52Kernel",
-                val=(Matern32Kernel() + ConstantKernel()) * Matern52Kernel(),
-                to_vec_grad=nothing,
-            ),
+            # THIS IS KNOWN NOT TO WORK!
+            # (
+            #     name="prod-(Matern32Kernel + ConstantKernel) * Matern52Kernel",
+            #     val=(Matern32Kernel() + ConstantKernel()) * Matern52Kernel(),
+            #     to_vec_grad=nothing,
+            # ),
 
             # Summed kernels.
             (


### PR DESCRIPTION
Implements approx periodic kernel via `to_sde`. I think this will effectively just swap out one set of problems for another (sum relies on `lgssm_components`, while `product` relies on `to_sde`). Basically `to_sde` assumes that the spectral density matrix `Q` can be described by a single parameter `q`. This is true a lot of the time, but it prevents us from combining SDEs with multi-dimensional noise, which is what we get for sums / products of kernels. I can't quite remember why I made this design choice when I first wrote this package, but it either needs to be revisited, or I need to figure out how to implement products of kernels in terms of `lgssm_components`.