### PR TITLE
Run cron job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Updates CI to run a cron job at midnight every day. This ought to mean that if anything gets accidentally messed up in Mooncake, we find out about it. It should also make it clear very quickly if there are any flakey tests.